### PR TITLE
feat: Add usage warning modal on application load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,29 @@
 // src/App.js
-import React from "react";
+// src/App.js
+import React, { useState, useEffect } from "react";
 import Landing from "./components/Landing";
 import SEO from "./components/SEO";
+import UsageWarningModal from './components/UsageWarningModal'; // Import the modal
 
 function App() {
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
+
+  useEffect(() => {
+    const warningAccepted = localStorage.getItem('phloxWarningAccepted');
+    if (warningAccepted !== 'true') {
+      setIsWarningModalOpen(true);
+    }
+  }, []);
+
+  const handleCloseWarningModal = () => {
+    setIsWarningModalOpen(false);
+  };
+
   return (
     <div className="App">
       <SEO />
       <Landing />
+      <UsageWarningModal isOpen={isWarningModalOpen} onClose={handleCloseWarningModal} />
     </div>
   );
 }

--- a/src/components/UsageWarningModal.jsx
+++ b/src/components/UsageWarningModal.jsx
@@ -1,0 +1,101 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Text,
+  VStack,
+  UnorderedList,
+  ListItem,
+  Box,
+  Heading
+} from '@chakra-ui/react';
+
+const UsageWarningModal = ({ isOpen, onClose }) => {
+  const [countdown, setCountdown] = useState(10);
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+
+  useEffect(() => {
+    if (isOpen) {
+      setCountdown(10); // Reset countdown when modal opens
+      setIsButtonDisabled(true);
+      const timer = setInterval(() => {
+        setCountdown(prevCountdown => {
+          if (prevCountdown <= 1) {
+            clearInterval(timer);
+            setIsButtonDisabled(false);
+            return 0;
+          }
+          return prevCountdown - 1;
+        });
+      }, 1000);
+      return () => clearInterval(timer);
+    }
+  }, [isOpen]);
+
+  const handleAccept = () => {
+    localStorage.setItem('phloxWarningAccepted', 'true');
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} closeOnOverlayClick={false} closeOnEsc={false} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Usage Warning</ModalHeader>
+        <ModalBody>
+          <VStack spacing={4} align="stretch">
+            <Text>
+              Phlox is an experimental project intended for educational and personal <Text as="strong">experimentation</Text> ONLY.
+            </Text>
+            <Text fontWeight="bold">
+              AS PROVIDED, IT IS NOT A CERTIFIED MEDICAL DEVICE AND MUST NOT BE USED IN ACTUAL CLINICAL SETTINGS or FOR CLINICAL DECISION-MAKING.
+            </Text>
+            <Text>
+              AI outputs can be unreliable and inaccurate. Always verify information and use professional clinical judgment.
+            </Text>
+            <Text>
+              For full details on limitations and risks, please read the <Text as="strong">Usage Warning</Text> section carefully before proceeding.
+            </Text>
+            <Heading as="h3" size="sm">Key limitations:</Heading>
+            <UnorderedList spacing={2}>
+              <ListItem>
+                <Text as="strong">Experimental Code:</Text> The software is under active development and may contain bugs or behave unexpectedly.
+              </ListItem>
+              <ListItem>
+                <Text as="strong">AI Hallucinations:</Text> The AI can generate incorrect or misleading information. Outputs are not a substitute for professional medical advice.
+              </ListItem>
+              <ListItem>
+                <Text as="strong">No User Authentication:</Text> The current version lacks user login/security features, making it unsuitable for sensitive data.
+              </ListItem>
+              <ListItem>
+                <Text as="strong">Not HIPAA/GDPR Compliant:</Text> The system does not meet regulatory standards for handling patient data.
+              </ListItem>
+            </UnorderedList>
+            <Text fontWeight="bold">
+              Use at your own risk and only for non-clinical, educational purposes unless you have implemented robust security measures and undertaken thorough validation.
+            </Text>
+          </VStack>
+        </ModalBody>
+        <ModalFooter>
+          <Text mr={3}>
+            {isButtonDisabled ? `Accept button unlocks in ${countdown}s` : "You can now accept."}
+          </Text>
+          <Button
+            colorScheme="blue"
+            onClick={handleAccept}
+            isDisabled={isButtonDisabled}
+          >
+            Accept
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default UsageWarningModal;


### PR DESCRIPTION
Implements a modal dialog that displays a critical usage warning to you when you first load the application.

Key features:
- The modal appears automatically on your initial visit.
- It contains a detailed warning about the experimental nature of Phlox, its non-certified status for clinical use, and AI limitations.
- A 10-second countdown timer prevents immediate dismissal.
- An "Accept" button is enabled after the countdown, which, when clicked, closes the modal and sets a flag in localStorage (`phloxWarningAccepted`) to prevent the modal from reappearing in the same browser session.

The modal is built using Chakra UI components and integrated into the main App component.